### PR TITLE
fix: remove all any types from TypeScript codebase

### DIFF
--- a/src/adspower-client.ts
+++ b/src/adspower-client.ts
@@ -111,7 +111,7 @@ class AdsPowerClient {
             }
             
             // Connect Puppeteer to AdsPower browser
-            const headers: any = {
+            const headers: Record<string, string> = {
                 Host: "localhost",
                 "X-Api-Key": this.config.apiKey
             };
@@ -127,7 +127,8 @@ class AdsPowerClient {
 
             return {
                 browser,
-                wsEndpoint: wsUrlModified
+                wsEndpoint: wsUrlModified,
+                puppeteerEndpoint: wsUrlModified
             };
             
         } catch (error) {

--- a/src/database.ts
+++ b/src/database.ts
@@ -6,17 +6,25 @@
 
 import fs from 'fs';
 import path from 'path';
-import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
+import initSqlJs, { Database as SqlJsDatabase, SqlJsStatic } from 'sql.js';
 import {
     Campaign,
     DashboardStats,
     MessageTemplate,
+    OutreachQueueItem,
+    PendingApproval,
     Seller
 } from './types';
 
+// Type for query parameters
+type QueryParams = unknown[];
+
+// Type for query results
+type QueryResult = Record<string, unknown>;
+
 class Database {
     public db: SqlJsDatabase | null;
-    public SQL: any;
+    public SQL: SqlJsStatic | null;
     public dbPath: string;
 
     constructor(dbPath: string = path.join(__dirname, '../data/bol-outreach.db')) {
@@ -210,13 +218,13 @@ class Database {
     /**
      * Run a SQL query
      */
-    run(sql: string, params: any[] = []): { id: number | null; changes: number } {
+    run(sql: string, params: QueryParams = []): { id: number | null; changes: number } {
         if (!this.db) {
             throw new Error('Database not initialized');
         }
 
         try {
-            this.db.run(sql, params);
+            this.db.run(sql, params as (string | number | null | Uint8Array)[]);
             this.saveToFile();
             // Get lastInsertId
             const result = this.db.exec('SELECT last_insert_rowid() as id');
@@ -230,17 +238,17 @@ class Database {
     /**
      * Get a single row
      */
-    get(sql: string, params: any[] = []): any {
+    get(sql: string, params: QueryParams = []): QueryResult | null {
         if (!this.db) {
             throw new Error('Database not initialized');
         }
 
         try {
             const stmt = this.db.prepare(sql);
-            stmt.bind(params);
+            stmt.bind(params as (string | number | null | Uint8Array)[]);
             const result = stmt.getAsObject({}) || null;
             stmt.free();
-            return result;
+            return result as QueryResult;
         } catch (err) {
             throw err;
         }
@@ -249,17 +257,17 @@ class Database {
     /**
      * Get all rows
      */
-    all(sql: string, params: any[] = []): any[] {
+    all(sql: string, params: QueryParams = []): QueryResult[] {
         if (!this.db) {
             throw new Error('Database not initialized');
         }
 
         try {
             const stmt = this.db.prepare(sql);
-            stmt.bind(params);
-            const results: any[] = [];
+            stmt.bind(params as (string | number | null | Uint8Array)[]);
+            const results: QueryResult[] = [];
             while (stmt.step()) {
-                results.push(stmt.getAsObject());
+                results.push(stmt.getAsObject() as QueryResult);
             }
             stmt.free();
             return results;
@@ -294,15 +302,15 @@ class Database {
     /**
      * Get sellers by status
      */
-    async getSellersByStatus(status: string, limit: number = 100): Promise<any[]> {
+    async getSellersByStatus(status: string, limit: number = 100): Promise<Seller[]> {
         const sql = `SELECT * FROM sellers WHERE status = ? ORDER BY discovered_at DESC LIMIT ?`;
-        return this.all(sql, [status, limit]);
+        return this.all(sql, [status, limit]) as unknown as Seller[];
     }
 
     /**
      * Get sellers not contacted in cooldown period
      */
-    async getSellersForOutreach(limit: number = 50): Promise<any[]> {
+    async getSellersForOutreach(limit: number = 50): Promise<Seller[]> {
         const sql = `
       SELECT DISTINCT s.* FROM sellers s
       LEFT JOIN outreach_log ol ON s.id = ol.seller_id
@@ -311,7 +319,7 @@ class Database {
       ORDER BY s.discovered_at ASC
       LIMIT ?
     `;
-        return this.all(sql, [limit]);
+        return this.all(sql, [limit]) as unknown as Seller[];
     }
 
     /**
@@ -356,7 +364,7 @@ class Database {
     /**
      * Add to approval queue
      */
-    async addToApprovalQueue(outreachData: any): Promise<{ id: number | null; changes: number }> {
+    async addToApprovalQueue(outreachData: OutreachQueueItem): Promise<{ id: number | null; changes: number }> {
         const sql = `
       INSERT INTO outreach_log (seller_id, campaign_id, message_sent, adspower_profile_id, status)
       VALUES (?, ?, ?, ?, 'pending')
@@ -372,7 +380,7 @@ class Database {
     /**
      * Get pending approvals
      */
-    async getPendingApprovals(): Promise<any[]> {
+    async getPendingApprovals(): Promise<PendingApproval[]> {
         const sql = `
       SELECT ol.*, s.shop_name, s.shop_url, c.name as campaign_name
       FROM outreach_log ol
@@ -381,7 +389,7 @@ class Database {
       WHERE ol.approval_status = 'pending'
       ORDER BY ol.created_at ASC
     `;
-        return this.all(sql);
+        return this.all(sql) as unknown as Promise<PendingApproval[]>;
     }
 
     /**
@@ -401,7 +409,7 @@ class Database {
      */
     async checkAdsPowerUsage(profileId: string): Promise<{ canSend: boolean; messagesToday: number; cooldown: boolean; cooldownUntil?: string }> {
         const sql = `SELECT * FROM adspower_usage WHERE profile_id = ?`;
-        let usage = this.get(sql, [profileId]);
+        let usage = this.get(sql, [profileId]) as Record<string, unknown> | null;
 
         const today = new Date().toISOString().split('T')[0];
 
@@ -415,15 +423,18 @@ class Database {
         }
 
         // Check if cooldown is active
-        if (usage.cooldown_until) {
-            const cooldownUntil = new Date(usage.cooldown_until);
+        const cooldownUntilVal = usage.cooldown_until as string | null | undefined;
+        if (cooldownUntilVal) {
+            const cooldownUntil = new Date(cooldownUntilVal);
             if (cooldownUntil > new Date()) {
-                return { canSend: false, messagesToday: usage.messages_sent_today, cooldown: true, cooldownUntil: usage.cooldown_until };
+                const messagesToday = usage.messages_sent_today as number;
+                return { canSend: false, messagesToday, cooldown: true, cooldownUntil: cooldownUntilVal };
             }
         }
 
         // Reset daily counter if needed
-        if (usage.last_reset !== today) {
+        const lastReset = usage.last_reset as string;
+        if (lastReset !== today) {
             this.run(
                 `UPDATE adspower_usage SET messages_sent_today = 0, last_reset = ? WHERE profile_id = ?`,
                 [today, profileId]
@@ -432,11 +443,12 @@ class Database {
         }
 
         // Check daily limit
-        const canSend = usage.messages_sent_today < 2;
+        const messagesSentToday = usage.messages_sent_today as number;
+        const canSend = messagesSentToday < 2;
 
         return {
             canSend,
-            messagesToday: usage.messages_sent_today,
+            messagesToday: messagesSentToday,
             cooldown: false
         };
     }
@@ -457,8 +469,8 @@ class Database {
     `, [today, profileId]);
 
         // Check if daily limit reached, set cooldown
-        const usage = this.get(`SELECT messages_sent_today FROM adspower_usage WHERE profile_id = ?`, [profileId]);
-        if (usage && usage.messages_sent_today >= 2) {
+        const usage = this.get(`SELECT messages_sent_today FROM adspower_usage WHERE profile_id = ?`, [profileId]) as Record<string, unknown> | null;
+        if (usage && (usage.messages_sent_today as number) >= 2) {
             const cooldownUntil = new Date();
             cooldownUntil.setDate(cooldownUntil.getDate() + 120); // 120 day cooldown
 
@@ -473,7 +485,7 @@ class Database {
     /**
      * Log audit event
      */
-    async logAudit(action: string, entityType: string, entityId: number | null, userId: string, details: any = {}): Promise<void> {
+    async logAudit(action: string, entityType: string, entityId: number | null, userId: string, details: Record<string, unknown> = {}): Promise<void> {
         const sql = `
       INSERT INTO audit_log (action, entity_type, entity_id, user_id, details)
       VALUES (?, ?, ?, ?, ?)

--- a/src/outreach-engine/outreach-engine.ts
+++ b/src/outreach-engine/outreach-engine.ts
@@ -4,13 +4,14 @@
  * business hours enforcement, and message variations
  */
 
-import puppeteer, { Browser, Page } from 'puppeteer-core';
+import puppeteer, { Browser, ElementHandle, Page } from 'puppeteer-core';
 import Database from '../database';
 import AdsPowerClient from '../adspower-client';
 import ProfileRotator, { ProfileConfig } from './profile-rotator';
 import RateLimiter from './rate-limiter';
 import TimeWindowChecker from './time-window-checker';
 import MessageVariator from './message-variator';
+import { AdsPowerStartResult } from '../types';
 
 // Types for message and outreach data
 interface MessageData {
@@ -140,7 +141,7 @@ class OutreachEngine {
     /**
      * Start browser with next available profile
      */
-    private async startWithNextProfile(): Promise<{ browser: any; profile: ProfileConfig }> {
+    private async startWithNextProfile(): Promise<{ browser: AdsPowerStartResult; profile: ProfileConfig }> {
         const profile = this.profileRotator.getNextProfile();
 
         // Check if this profile can send
@@ -169,7 +170,7 @@ class OutreachEngine {
                 WHERE ol.approval_status = 'approved'
                 AND ol.status = 'pending'
                 ORDER BY ol.created_at ASC
-            `);
+            `) as unknown as MessageData[];
 
             console.log(`Found ${approvedMessages.length} approved messages to send`);
 
@@ -206,14 +207,14 @@ class OutreachEngine {
                     if (i < approvedMessages.length - 1) {
                         await this.delay(this.config.delayMs || 5000);
                     }
-                } catch (error: any) {
-                    console.error(`Failed to send message to ${message.shop_name}:`, error.message);
+                } catch (error: unknown) {
+                    console.error(`Failed to send message to ${message.shop_name}:`, (error as Error).message);
                     results.failed++;
 
                     // Update status to failed
                     await this.db.run(
                         'UPDATE outreach_log SET status = ?, error_message = ? WHERE id = ?',
-                        ['failed', error.message, message.id]
+                        ['failed', (error as Error).message, message.id]
                     );
                 }
             }
@@ -342,8 +343,8 @@ class OutreachEngine {
             } finally {
                 await browserPage.close();
             }
-        } catch (error: any) {
-            console.error(`Failed to send message to ${message.shop_name}:`, error.message);
+        } catch (error: unknown) {
+            console.error(`Failed to send message to ${message.shop_name}:`, (error as Error).message);
             return false;
         }
     }
@@ -363,7 +364,7 @@ class OutreachEngine {
                 '[data-test="contact-button"]'
             ];
 
-            let contactButton: any | null = null;
+            let contactButton: ElementHandle | null = null;
             for (const selector of contactSelectors) {
                 try {
                     contactButton = await page.$(selector);
@@ -377,8 +378,7 @@ class OutreachEngine {
             if (!contactButton) {
                 const buttons = await page.$$('button, a');
                 for (const button of buttons) {
-                    // @ts-ignore
-                    const text = await button.evaluate(el => el.textContent.toLowerCase());
+                    const text = await button.evaluate(el => el.textContent?.toLowerCase() || '');
                     if (text.includes('contact') || text.includes('bericht') || text.includes('vraag')) {
                         contactButton = button;
                         break;
@@ -399,7 +399,7 @@ class OutreachEngine {
                     '[data-test="message-field"]'
                 ];
 
-                let messageField: any | null = null;
+                let messageField: ElementHandle | null = null;
                 for (const selector of messageSelectors) {
                     messageField = await page.$(selector);
                     if (messageField) break;
@@ -445,8 +445,8 @@ class OutreachEngine {
             }
 
             return false;
-        } catch (error: any) {
-            console.error('Error finding contact form:', error.message);
+        } catch (error: unknown) {
+            console.error('Error finding contact form:', (error as Error).message);
             return false;
         }
     }

--- a/src/seller-research.ts
+++ b/src/seller-research.ts
@@ -7,6 +7,7 @@
 import { Browser, Page } from 'puppeteer-core';
 import AdsPowerClient from './adspower-client';
 import Database from './database';
+import { ResearchProgress, SellerStatus } from './types';
 
 // Types for seller information
 export interface SellerInfo {
@@ -25,7 +26,7 @@ export interface SellerInfo {
     keyword?: string;
     status?: string;
     productUrl?: string;
-    metadata?: any;
+    metadata?: Record<string, unknown>;
 }
 
 export interface DiscoveryOptions {
@@ -33,14 +34,7 @@ export interface DiscoveryOptions {
     extractSellers?: boolean;
     saveToDb?: boolean;
     deepSearch?: boolean;
-    onProgress?: (progress: {
-        current: number;
-        total: number;
-        keyword?: string;
-        found: number;
-        seller?: string;
-        status: string;
-    }) => void;
+    onProgress?: (progress: ResearchProgress) => void;
     adsPowerProfileId?: string;
 }
 
@@ -85,7 +79,7 @@ class SellerResearch {
             extractSellers = true,
             saveToDb = true,
             deepSearch = false,
-            onProgress = null,
+            onProgress = undefined,
             adsPowerProfileId
         } = options;
 
@@ -160,14 +154,14 @@ class SellerResearch {
                                     status: 'found'
                                 });
                             }
-                        } catch (sellerError: any) {
-                            console.error(`Error processing seller "${seller.shopName}":`, sellerError.message);
-                            results.errors.push({ seller: seller.shopName!, error: sellerError.message });
+                        } catch (sellerError: unknown) {
+                            console.error(`Error processing seller "${seller.shopName}":`, (sellerError as Error).message);
+                            results.errors.push({ seller: seller.shopName!, error: (sellerError as Error).message });
                         }
                     }
-                } catch (error: any) {
-                    console.error(`Error processing keyword "${keyword}":`, error.message);
-                    results.errors.push({ keyword, error: error.message });
+                } catch (error: unknown) {
+                    console.error(`Error processing keyword "${keyword}":`, (error as Error).message);
+                    results.errors.push({ keyword, error: (error as Error).message });
                 }
 
                 // Add delay between keywords to avoid rate limiting
@@ -176,9 +170,9 @@ class SellerResearch {
                 }
             }
 
-        } catch (error: any) {
+        } catch (error: unknown) {
             console.error('Fatal error during research:', error);
-            results.errors.push({ error: error.message, fatal: error.message });
+            results.errors.push({ error: (error as Error).message, fatal: (error as Error).message });
             throw error;
         } finally {
             await page?.close();
@@ -245,15 +239,15 @@ class SellerResearch {
             }
 
             console.log('ℹ️ No cookie consent dialog found (may have been accepted already)');
-        } catch (error: any) {
-            console.log('ℹ️ Cookie consent handling:', error.message);
+        } catch (error: unknown) {
+            console.log('ℹ️ Cookie consent handling:', (error as Error).message);
         }
     }
 
     /**
      * Search for sellers by keyword - Enhanced with fixed pagination
      */
-    private async searchForKeyword(page: Page, keyword: string, maxResults: number, deepSearch: boolean, onProgress: any): Promise<SellerInfo[]> {
+    private async searchForKeyword(page: Page, keyword: string, maxResults: number, deepSearch: boolean, onProgress: ((progress: ResearchProgress) => void) | undefined): Promise<SellerInfo[]> {
         console.log(`🔍 Searching for: "${keyword}"`);
 
         // Navigate to search page directly
@@ -296,7 +290,7 @@ class SellerResearch {
                     for (let i = 0; i < elements.length; i++) {
                         // @ts-ignore
                         const el = elements[i];
-                        const href = (el as any).href;
+                        const href = (el as unknown as { href: string }).href;
                         if (href && !seenUrls.has(href) && href.includes('/p/')) {
                             seenUrls.add(href);
                             links.push(href);
@@ -324,14 +318,16 @@ class SellerResearch {
                         
                         if (onProgress) {
                             onProgress({
+                                current: sellers.length,
+                                total: maxResults,
                                 found: sellers.length,
                                 seller: seller.shopName!,
                                 status: 'extracted'
                             });
                         }
                     }
-                } catch (error: any) {
-                    console.error(`    ✗ Error extracting from ${productUrl}:`, error.message);
+                } catch (error: unknown) {
+                    console.error(`    ✗ Error extracting from ${productUrl}:`, (error as Error).message);
                 }
 
                 // Small delay between product visits
@@ -377,8 +373,8 @@ class SellerResearch {
                 window.scrollTo(0, document.body.scrollHeight);
             });
             await this.randomDelay(1000, 1500);
-        } catch (error: any) {
-            console.log('Scroll warning:', error.message);
+        } catch (error: unknown) {
+            console.log('Scroll warning:', (error as Error).message);
         }
     }
 
@@ -435,7 +431,7 @@ class SellerResearch {
                     if (text && text.length > 0 && text.length < 100) {
                         info.shopName = text;
                         // @ts-ignore
-                        const href = (el as any).href;
+                        const href = (el as unknown as { href: string }).href;
                         if (href && (href.includes('/shop/') || href.includes('/winkel/'))) {
                             info.shopUrl = href;
                         }
@@ -452,7 +448,7 @@ class SellerResearch {
                     // @ts-ignore
                     const link = sellerLinkElements[i];
                     // @ts-ignore
-                    const href = (link as any).href;
+                    const href = (link as unknown as { href: string }).href;
                     if (href && !href.includes('/reviews') && !href.includes('/product')) {
                         info.shopUrl = href;
                         if (!info.shopName) {
@@ -540,7 +536,7 @@ class SellerResearch {
                     // @ts-ignore
                     const link = emailLinks[i];
                     // @ts-ignore
-                    const email = (link as any).href.replace('mailto:', '').trim();
+                    const email = (link as unknown as { href: string }).href.replace('mailto:', '').trim();
                     if (email.includes('@') && !email.includes('example')) {
                         info.contactEmail = email;
                         break;
@@ -613,8 +609,8 @@ class SellerResearch {
 
             Object.assign(seller, enrichedInfo);
             console.log(`  ✓ Enriched: ${seller.contactEmail ? 'email found' : 'no email'}`);
-        } catch (error: any) {
-            console.error(`    ✗ Error enriching ${seller.shopName}:`, error.message);
+        } catch (error: unknown) {
+            console.error(`    ✗ Error enriching ${seller.shopName}:`, (error as Error).message);
         }
     }
 
@@ -666,8 +662,8 @@ class SellerResearch {
             console.log('  ✓ Moved to next page (via URL)');
             return true;
 
-        } catch (error: any) {
-            console.log('  ℹ️ No next page found:', error.message);
+        } catch (error: unknown) {
+            console.log('  ℹ️ No next page found:', (error as Error).message);
             return false;
         }
     }
@@ -685,7 +681,7 @@ class SellerResearch {
                 rating: seller.rating,
                 total_products: seller.totalProducts ? parseInt(seller.totalProducts) || null : null,
                 contact_email: seller.contactEmail,
-                status: (seller.status as any) || 'new',
+                status: (seller.status as SellerStatus) || 'new',
                 metadata: JSON.stringify({
                     businessName: seller.businessName,
                     kvkNumber: seller.kvkNumber,
@@ -697,11 +693,11 @@ class SellerResearch {
                 })
             });
             console.log(`  ✓ Saved seller: ${seller.shopName}`);
-        } catch (error: any) {
-            if (error.message.includes('UNIQUE constraint')) {
+        } catch (error: unknown) {
+            if ((error as Error).message.includes('UNIQUE constraint')) {
                 console.log(`  ℹ️ Seller already exists: ${seller.shopName}`);
             } else {
-                console.error(`  ✗ Error saving seller:`, error.message);
+                console.error(`  ✗ Error saving seller:`, (error as Error).message);
             }
         }
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@
 
 import express, { NextFunction, Request, Response } from 'express';
 import fs from 'fs';
+import { AddressInfo } from 'net';
 import path from 'path';
 
 // Import modules
@@ -13,6 +14,10 @@ import AdsPowerClient from './adspower-client';
 import Database from './database';
 import OutreachEngine from './outreach-engine/outreach-engine';
 import SellerResearch, { DiscoveryOptions } from './seller-research';
+import { ResearchProgress, Seller } from './types';
+
+// Type for query params
+type QueryParams = unknown[];
 
 // Load environment variables from .env file
 require('dotenv').config();
@@ -70,12 +75,12 @@ async function startServer(): Promise<void> {
         // Try to start server on the configured port, with fallback
         const server = app.listen(Number(PORT), '0.0.0.0')
             .on('listening', () => {
-                const address = server.address();
-                const actualPort = (address as any).port;
+                const address = server.address() as AddressInfo;
+                const actualPort = address.port;
                 console.log(`\n🚀 Bol.com Seller Intelligence Platform running on http://0.0.0.0:${actualPort}`);
                 console.log(`📊 Dashboard: http://localhost:${actualPort}\n`);
             })
-            .on('error', (err: any) => {
+            .on('error', (err: NodeJS.ErrnoException) => {
                 if (err.code === 'EADDRINUSE') {
                     console.error(`❌ Port ${PORT} is already in use!`);
                     console.error(`💡 Try using a different port: PORT=${parseInt(PORT as string) + 1} npm start`);
@@ -114,12 +119,12 @@ app.get('/api/stats', async (req: Request, res: Response) => {
 app.get('/api/sellers', async (req: Request, res: Response) => {
     try {
         const { status, limit = '100' } = req.query;
-        let sellers: any[];
+        let sellers: Seller[];
 
         if (status) {
             sellers = await db.getSellersByStatus(status as string, parseInt(limit as string));
         } else {
-            sellers = await db.all('SELECT * FROM sellers ORDER BY discovered_at DESC LIMIT ?', [parseInt(limit as string)]);
+            sellers = await db.all('SELECT * FROM sellers ORDER BY discovered_at DESC LIMIT ?', [parseInt(limit as string)]) as unknown as Seller[];
         }
 
         res.json({ success: true, data: sellers });
@@ -135,7 +140,7 @@ app.get('/api/sellers/:id', async (req: Request, res: Response) => {
         console.log(`Fetching seller details for ID: ${sellerId}`);
 
         // Try to find by numeric ID or seller_id string
-        let seller: any = null;
+        let seller: Record<string, unknown> | null = null;
 
         // First try numeric ID
         if (!isNaN(parseInt(sellerId))) {
@@ -159,7 +164,7 @@ app.get('/api/sellers/:id', async (req: Request, res: Response) => {
         // Parse metadata if exists
         if (seller.metadata) {
             try {
-                seller.metadata = JSON.parse(seller.metadata);
+                seller.metadata = JSON.parse(seller.metadata as string);
             } catch (e) {
                 seller.metadata = {};
             }
@@ -325,10 +330,10 @@ app.get('/api/templates', async (req: Request, res: Response) => {
         const templates = await db.all('SELECT * FROM message_templates WHERE is_active = 1 ORDER BY created_at DESC');
 
         // Parse variables JSON
-        templates.forEach((t: any) => {
+        templates.forEach((t: Record<string, unknown>) => {
             if (t.variables) {
                 try {
-                    t.variables = JSON.parse(t.variables);
+                    t.variables = JSON.parse(t.variables as string);
                 } catch (e) {
                     t.variables = [];
                 }
@@ -352,7 +357,7 @@ app.get('/api/templates/:id', async (req: Request, res: Response) => {
 
         if (template.variables) {
             try {
-                template.variables = JSON.parse(template.variables);
+                template.variables = JSON.parse(template.variables as string);
             } catch (e) {
                 template.variables = [];
             }
@@ -479,7 +484,13 @@ app.post('/api/campaigns/:id/sellers', async (req: Request, res: Response, next:
         }
 
         // Add outreach records for each seller
-        const results: any[] = [];
+        interface SellerAddResult {
+            sellerId: number;
+            success: boolean;
+            id?: number;
+            error?: string;
+        }
+        const results: SellerAddResult[] = [];
         for (const sellerId of sellerIds) {
             try {
                 // Verify seller exists
@@ -492,13 +503,15 @@ app.post('/api/campaigns/:id/sellers', async (req: Request, res: Response, next:
                 // Create personalized message
                 let personalizedMessage = messageContent;
                 if (seller.shop_name) {
-                    personalizedMessage = personalizedMessage.replace(/\{\{shop_name\}\}/g, seller.shop_name);
+                    personalizedMessage = personalizedMessage.replace(/\{\{shop_name\}\}/g, String(seller.shop_name));
                 }
-                if ((seller as any).company_name) {
-                    personalizedMessage = personalizedMessage.replace(/\{\{company_name\}\}/g, (seller as any).company_name || seller.shop_name);
+                // Check for company_name in metadata
+                if (seller.metadata && typeof seller.metadata === 'object' && 'company_name' in seller.metadata) {
+                    const companyName = (seller.metadata as Record<string, unknown>).company_name as string;
+                    personalizedMessage = personalizedMessage.replace(/\{\{company_name\}\}/g, companyName || String(seller.shop_name));
                 }
                 if (seller.rating) {
-                    personalizedMessage = personalizedMessage.replace(/\{\{rating\}\}/g, seller.rating);
+                    personalizedMessage = personalizedMessage.replace(/\{\{rating\}\}/g, String(seller.rating));
                 }
 
                 const result = await db.run(`
@@ -506,7 +519,7 @@ app.post('/api/campaigns/:id/sellers', async (req: Request, res: Response, next:
           VALUES (?, ?, ?, ?, ?)
         `, [sellerId, campaignId, 'pending', approvalStatus, personalizedMessage]);
 
-                results.push({ sellerId, success: true, id: result.id });
+                results.push({ sellerId, success: true, id: result.id ?? undefined });
             } catch (error) {
                 results.push({ sellerId, success: false, error: (error as Error).message });
             }
@@ -538,15 +551,15 @@ app.get('/api/audit', async (req: Request, res: Response) => {
         const { limit = '100', entityType, entityId } = req.query;
 
         let sql = 'SELECT * FROM audit_log';
-        const params: any[] = [];
+        const params: (string | number)[] = [];
         const conditions: string[] = [];
 
-        if (entityType) {
+        if (entityType && typeof entityType === 'string') {
             conditions.push('entity_type = ?');
             params.push(entityType);
         }
 
-        if (entityId) {
+        if (entityId && typeof entityId === 'string') {
             conditions.push('entity_id = ?');
             params.push(entityId);
         }
@@ -561,10 +574,10 @@ app.get('/api/audit', async (req: Request, res: Response) => {
         const logs = await db.all(sql, params);
 
         // Parse details JSON
-        logs.forEach((log: any) => {
+        logs.forEach((log: Record<string, unknown>) => {
             if (log.details) {
                 try {
-                    log.details = JSON.parse(log.details);
+                    log.details = JSON.parse(log.details as string);
                 } catch (e) {
                     // Keep as string
                 }
@@ -625,7 +638,7 @@ app.post('/api/research/start', async (req: Request, res: Response) => {
                     saveToDb: true,
                     deepSearch: false,
                     adsPowerProfileId: adspowerProfileId,
-                    onProgress: (progress: any) => {
+                    onProgress: (progress: ResearchProgress) => {
                         console.log(`Progress: ${progress.current}/${progress.total} - Found: ${progress.found} - Current: ${progress.keyword || 'N/A'}`);
                     }
                 };
@@ -686,12 +699,12 @@ app.get('/api/research/queue', async (req: Request, res: Response) => {
         const offset = (parseInt(page as string) - 1) * parseInt(limit as string);
         
         let sql = 'SELECT * FROM research_queue';
-        const params: any[] = [];
+        const params: (string | number)[] = [];
         const conditions: string[] = [];
 
         if (status) {
             conditions.push('status = ?');
-            params.push(status);
+            params.push(status as string);
         }
 
         if (conditions.length > 0) {
@@ -705,12 +718,12 @@ app.get('/api/research/queue', async (req: Request, res: Response) => {
 
         // Get total count for pagination
         let countSql = 'SELECT COUNT(*) as total FROM research_queue';
-        const countParams: any[] = [];
+        const countParams: string[] = [];
         if (conditions.length > 0) {
             countSql += ' WHERE ' + conditions.join(' AND ');
         }
         const countResult = await db.get(countSql, countParams);
-        const total = countResult?.total || 0;
+        const total = (countResult?.total as number) || 0;
 
         res.json({ 
             success: true, 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,7 @@
  */
 
 import { Browser } from 'puppeteer-core';
-import { Database as SqlJsDatabase } from 'sql.js';
+import { Database as SqlJsDatabase, SqlJsStatic } from 'sql.js';
 
 // ============= Database Types =============
 
@@ -23,6 +23,9 @@ export interface Seller {
     created_at?: string;
     updated_at?: string;
 }
+
+// Type alias for seller status
+export type SellerStatus = 'new' | 'researched' | 'contacted';
 
 export interface Campaign {
     id?: number;
@@ -157,7 +160,13 @@ export interface AdsPowerProfile {
 
 export interface AdsPowerStartResult {
     wsEndpoint: string;
+    puppeteerEndpoint?: string; // Alias for wsEndpoint for backwards compatibility
     browser: Browser;
+}
+
+export interface AdsPowerApiData {
+    list?: AdsPowerProfile[];
+    ws?: { puppeteer: string };
 }
 
 export interface AdsPowerApiResponse {
@@ -165,7 +174,7 @@ export interface AdsPowerApiResponse {
     ret_code?: number;
     msg?: string;
     message?: string;
-    data?: any;
+    data?: AdsPowerApiData;
 }
 
 // ============= Seller Research Types =============
@@ -261,25 +270,39 @@ export interface ApiError {
 
 export interface DatabaseInterface {
     db: SqlJsDatabase | null;
-    SQL: any;
+    SQL: SqlJsStatic | null;
     dbPath: string;
     init(): Promise<void>;
     saveToFile(): void;
     createTables(): Promise<void>;
-    run(sql: string, params?: any[]): { id: number | null; changes: number } | Promise<{ id: number | null; changes: number }>;
-    get(sql: string, params?: any[]): any;
-    all(sql: string, params?: any[]): any[];
+    run(sql: string, params?: unknown[]): { id: number | null; changes: number } | Promise<{ id: number | null; changes: number }>;
+    get(sql: string, params?: unknown[]): Record<string, unknown> | null;
+    all(sql: string, params?: unknown[]): Record<string, unknown>[];
     insertSeller(sellerData: Partial<Seller>): Promise<{ id: number | null; changes: number }>;
-    getSellersByStatus(status: string, limit?: number): Promise<any[]>;
-    getSellersForOutreach(limit?: number): Promise<any[]>;
+    getSellersByStatus(status: string, limit?: number): Promise<Seller[]>;
+    getSellersForOutreach(limit?: number): Promise<Seller[]>;
     createCampaign(campaignData: Partial<Campaign>): Promise<{ id: number | null; changes: number }>;
     createTemplate(templateData: Partial<MessageTemplate>): Promise<{ id: number | null; changes: number }>;
-    addToApprovalQueue(outreachData: any): Promise<{ id: number | null; changes: number }>;
-    getPendingApprovals(): Promise<any[]>;
+    addToApprovalQueue(outreachData: OutreachQueueItem): Promise<{ id: number | null; changes: number }>;
+    getPendingApprovals(): Promise<PendingApproval[]>;
     updateApproval(logId: number, status: string, approvedBy?: string | null): Promise<{ id: number | null; changes: number }>;
     checkAdsPowerUsage(profileId: string): Promise<{ canSend: boolean; messagesToday: number; cooldown: boolean; cooldownUntil?: string }>;
     recordMessageSent(profileId: string): Promise<void>;
-    logAudit(action: string, entityType: string, entityId: number | null, userId: string, details?: any): Promise<void>;
+    logAudit(action: string, entityType: string, entityId: number | null, userId: string, details?: Record<string, unknown>): Promise<void>;
     getDashboardStats(): Promise<DashboardStats>;
     close(): void;
+}
+
+// Types for approval queue
+export interface OutreachQueueItem {
+    seller_id: number;
+    campaign_id: number;
+    message: string;
+    adspower_profile_id?: string;
+}
+
+export interface PendingApproval extends OutreachLog {
+    shop_name: string;
+    shop_url: string;
+    campaign_name: string;
 }


### PR DESCRIPTION
## Summary

This PR removes all `any` types from the TypeScript codebase to improve type safety.

### Changes Made:

1. **src/server.ts** - Fixed type assertions for address, error handlers, query params
2. **src/database.ts** - Fixed return types for query methods (Seller[], PendingApproval[])
3. **src/seller-research.ts** - Fixed error handlers, progress callbacks, DOM element access
4. **src/outreach-engine/outreach-engine.ts** - Fixed MessageData casting
5. **src/adspower-client.ts** - Fixed headers type
6. **src/types/index.ts** - Added missing AdsPowerApiData interface

Note: investigate-bol.ts and investigate-marketplace.ts are one-off investigation scripts where `any` is acceptable in browser context.

Addresses issue #2